### PR TITLE
docs: add additional package json info

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 
 # Copy package files and install dependencies first (for better layer caching)
 COPY package.json package-lock.json ./
-RUN npm ci --only=production && npm cache clean --force
+RUN npm ci --only=production
 
 # Copy source code and build
 COPY . .

--- a/home-lab/media/index.md
+++ b/home-lab/media/index.md
@@ -12,4 +12,4 @@ You will primarily find tools, guides, resources, and scripts here that can be u
 
 **At the end of the day, you kind of just pick a spot and start.** A common place to start is to first follow the steps below to help you get the best experience.
 
-1. If you aren't familiar with, or don't have any experience with Docker, I highly recommend spending some time learning about Docker and how to use it. I recommend checking out Techno Tim's docker content ([Written](https://technotim.live/tags/docker/)), orNetworkChuck's docker content ([Videos](https://www.youtube.com/watch?v=eGz9DS-aIeY)).
+1. If you aren't familiar with, or don't have any experience with Docker, I highly recommend spending some time learning about Docker and how to use it. I recommend checking out Techno Tim's Docker content ([Written](https://technotim.live/tags/docker/)), or NetworkChuck's Docker content ([Videos](https://www.youtube.com/watch?v=eGz9DS-aIeY)).

--- a/home-lab/media/jellyfin/getting-started/selecting-your-hardware.md
+++ b/home-lab/media/jellyfin/getting-started/selecting-your-hardware.md
@@ -8,13 +8,13 @@ When selecting your Jellyfin server hardware, keep the following factors in mind
 
 ### Processor (CPU)
 
-The CPU is arguably the most important component, especially if you anticipate a lot of **transcoding**. Transcoding is the process of converting a media file from one format to another on-the-fly, which is often necessary when your client device doesn't support the original file format, or your internet connection isn't fast enough for direct playback.
+The CPU is arguably the most important component, especially if you anticipate a lot of **transcoding**. Transcoding is the process of converting a media file from one format to another on the fly, which is often necessary when your client device doesn't support the original file format, or your internet connection isn't fast enough for direct playback.
 
 * **No Transcoding (Direct Play):** If all your devices can direct play your media (meaning they support the original file format and bitrate), then even a low-power CPU like an Intel Celeron or an ARM-based single-board computer (SBC) like a Raspberry Pi 4 might suffice for a few simultaneous streams.
-* **Software Transcoding:** This relies solely on the CPU. For 1080p transcodes, you'll want something like an Intel Core i3 (7th gen or newer) or an AMD Ryzen 3. For multiple 1080p streams or any 4K transcoding, an Intel Core i5/i7 (7th gen or newer) or AMD Ryzen 5/7 is recommended. The more streams and higher resolutions, the more powerful your CPU needs to be.
+* **Software Transcoding:** This relies solely on the CPU. For 1080p transcodes, you'll want something like an Intel Core i3 (7th gen or newer) or an AMD Ryzen 3. For multiple 1080p streams or any 4K transcoding, an Intel Core i5/i7 (7th gen or newer) or AMD Ryzen 5/7 is recommended. The more streams and higher resolutions you have, the more powerful your CPU needs to be.
 * **Hardware Transcoding (Recommended):** This offloads the transcoding process to a dedicated hardware encoder/decoder on the CPU or GPU, significantly reducing CPU load and power consumption.
     * **Intel Quick Sync Video (QSV):** Most modern Intel CPUs (7th generation or newer, especially those with an "F" suffix are generally not recommended as they lack integrated graphics for QSV) have excellent integrated graphics that support QSV. This is often the most cost-effective and power-efficient solution for transcoding. Look for CPUs with integrated graphics (e.g., i3-7100, i5-8400, i7-10700).
-    * **NVIDIA NVENC/NVDEC:** Dedicated NVIDIA GPUs (GTX 1050 or newer, RTX series) also offer excellent hardware transcoding capabilities via NVENC. This is a good option if you already have a compatible GPU or require more transcoding power than integrated graphics can provide. Note that consumer NVIDIA cards have a limit on simultaneous transcodes (usually 2-3), which can be bypassed with a driver patch. Professional Quadro cards do not have this limitation.
+    * **NVIDIA NVENC/NVDEC:** Dedicated NVIDIA GPUs (GTX 1050 or newer, RTX series) also offer excellent hardware transcoding capabilities via NVENC. This is a good option if you already have a compatible GPU or require more transcoding power than integrated graphics can provide. Note that consumer NVIDIA cards have a limit on the number of simultaneous transcodes (usually 2-3), which can be bypassed with a driver patch. Professional Quadro cards do not have this limitation.
     * **AMD VCE/VCN:** AMD's integrated and dedicated GPUs also offer hardware encoding, though historically, their performance in Jellyfin hasn't been as consistently praised as Intel's QSV or NVIDIA's NVENC. However, newer AMD APUs and GPUs are becoming more competitive.
 
 ### RAM
@@ -26,7 +26,7 @@ The CPU is arguably the most important component, especially if you anticipate a
 ### Disk Space (Storage)
 
 * **Operating System & Jellyfin Data:** A small Solid State Drive (SSD) (120GB-250GB) for your operating system and Jellyfin's application data (metadata, images, transcoded temporary files) will provide snappy performance.
-* **Media Storage:** For your actual media files, you'll want large capacity Hard Disk Drives (HDDs).
+* **Media Storage:** For your actual media files, you'll want large-capacity Hard Disk Drives (HDDs).
     * **Single Drive:** Simplest for small collections.
     * **Multiple Drives (RAID/ZFS):** For larger collections and data redundancy (protection against drive failure), consider setting up a RAID array (e.g., RAID 1 for mirroring, RAID 5/6 for parity) or using a file system like ZFS. This protects your valuable media collection.
     * **Network Attached Storage (NAS):** Many users opt for a dedicated NAS device (like a Synology, QNAP, or a DIY FreeNAS/TrueNAS build) to store their media, then run Jellyfin either directly on the NAS (if it's powerful enough) or on a separate, more powerful machine that accesses the media over the network.
@@ -47,7 +47,7 @@ The CPU is arguably the most important component, especially if you anticipate a
     * **CPU:** Intel Celeron/Pentium (newer generations with Quick Sync) or Raspberry Pi 4 (for ARM-compatible builds and very light loads).
     * **RAM:** 4GB
     * **Storage:** Small SSD for OS, 1-2TB HDD for media.
-    * **Use Case:** Ideal for single users or small families primarily direct playing content on devices that support it.
+    * **Use Case:** Ideal for single users or small families, primarily direct playing content on devices that support it.
 
 * **Mid-Range (Multiple 1080p Transcodes/Light 4K Transcoding - 2-4 users):**
     * **CPU:** Intel Core i3/i5 (7th gen or newer with Quick Sync) or AMD Ryzen 3/5 (with integrated graphics or a dedicated low-power GPU like an NVIDIA GT 1030/1050).

--- a/home-lab/media/jellyfin/getting-started/what-is-it.md
+++ b/home-lab/media/jellyfin/getting-started/what-is-it.md
@@ -6,7 +6,7 @@ Jellyfin is a free and open-source media system that puts you in control of your
 
 * **Self-Hosted Freedom:** Unlike many commercial media servers, Jellyfin is designed to be self-hosted. This means you install and run the server software on your own computer, server, or even a network-attached storage (NAS) device. You retain full control over your data, privacy, and how your media is accessed.
 * **Broad Device Support:** Jellyfin offers a wide range of client applications for various platforms, including:
-    * Web browsers (via its intuitive web interface)
+    * Web browsers (via their intuitive web interface)
     * Mobile devices (Android, iOS)
     * Smart TVs (Android TV, Apple TV, Roku, Fire TV)
     * Gaming consoles (Xbox, PlayStation)
@@ -28,4 +28,4 @@ When you want to watch a movie, your client device requests the content from you
 
 ## Is Jellyfin Right for You?
 
-If you're looking for a powerful, flexible, and privacy-focused way to manage and stream your personal media collection, Jellyfin is an excellent choice. It empowers you with complete control over your media empire, without being tied to proprietary services or recurring costs. While it might require a bit more initial setup than some commercial alternatives, the benefits of true ownership and open-source freedom are well worth the effort for many users.
+If you're looking for a powerful, flexible, and privacy-focused way to manage and stream your personal media collection, Jellyfin is an excellent choice. It empowers you with complete control over your media empire, without being tied to proprietary services or recurring costs. While it requires more initial setup than some commercial alternatives, the benefits of true ownership and open-source freedom are well worth the effort for many users.

--- a/home-lab/media/jellyfin/troubleshooting/jellyfin-proxy-fix.md
+++ b/home-lab/media/jellyfin/troubleshooting/jellyfin-proxy-fix.md
@@ -1,37 +1,37 @@
 # Correcting Incorrect IP Addresses for Jellyfin Users behind a Proxy
 
-## nginX Proxy Manager
+## Nginx Proxy Manager
 
-- You are using [nginX Proxy Manager](https://nginxproxymanager.com/) as your proxying service
+- You are using [Nginx Proxy Manager](https://nginxproxymanager.com/) as your proxying service
 - You are using a [Jellyfin](https://jellyfin.org/) media streaming server
 
 ### Cause
 
-This occurs because your nginX proxy is not properly forwarding the incoming IP address and client information to the devices behind the proxy. By default Jellyfin also does not assume that it is behind a proxy, so it does not look for this incoming information - even if you DO have your nginX proxy configuration set up properly.
+This occurs because your Nginx proxy is not properly forwarding the incoming IP address and client information to the devices behind the proxy. By default, Jellyfin also does not assume that it is behind a proxy, so it does not look for this incoming information - even if you DO have your Nginx proxy configuration set up properly.
 
 ### Correction Steps
 
 You can fix this issue by following the steps below.
 
-#### Update your nginX Proxy Manager configuration 
+#### Update your Nginx Proxy Manager configuration 
 
-1. Go into your nginx proxy manager, and find the 'host' for the external domain name that you have connected to your Jellyfin (Example: `jellyfin.example.com`)
+1. Go into your Nginx Proxy Manager, and find the 'host' for the external domain name that you have connected to your Jellyfin (Example: `jellyfin.example.com`)
 2. Go to the advanced tab and paste in the following information:
    `proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; proxy_set_header X-Forwarded-Proto $scheme;`
 3) Click Save
 
 #### Update your Jellyfin Network Configuration 
 
-1. Go to your NAS and find the jellyfin `/config` folder in your docker storage (not in Portainer, in your file manager in your NAS) 
+1. Go to your NAS and find the jellyfin `/config` folder in your Docker storage (not in Portainer, in your file manager in your NAS) 
 2. Find the `network.xml` file and add the line:
    `<IsBehindProxy>true</IsBehindProxy>`
-3. Save the file, and restart the docker container
+3. Save the file, and restart the Docker container
 
 > **Note:** This file WILL persist after container deletion, since it's mapped to your disk
 
-#### Add IP of Proxy to Known Proxies in Jellyfin
+#### Add the IP of the Proxy to the Known Proxies in Jellyfin
 
 1. Go to your Jellyfin Admin Dashboard
 2. Go to 'Networking'
-3. Go to 'Server Address Settings > Known proxies', and enter in the IP of your nginX proxy server
+3. Go to 'Server Address Settings > Known proxies', and enter in the IP of your Nginx proxy server
 4. Save

--- a/home-lab/virtualization/kubernetes/getting-started/what-is-it.md
+++ b/home-lab/virtualization/kubernetes/getting-started/what-is-it.md
@@ -6,11 +6,11 @@ Kubernetes is an open-source platform that automates the deployment, scaling, an
 
 If I could describe the three benefits of Kubernetes in bullet points, I'd list them as follows:
 
-- **Container Deployment Automation** - Kubernetes is particularly strong at deploying applications with an automated rollout, reducing the overall time spent to launch an application once configuration files are in place. Additionally, when the application exceeds it's load quotas, the app can scale horizontally automatically if necessary, to increase the capacity of the app to keep systems online.
+- **Container Deployment Automation** - Kubernetes is particularly strong at deploying applications with an automated rollout, reducing the overall time spent to launch an application once configuration files are in place. Additionally, when the application exceeds its load quotas, the app can scale horizontally automatically if necessary, to increase the capacity of the app to keep systems online.
 - **Extensibility & Customization** - You can do literally ANYTHING with Kubernetes. Well, not *anything* but just about. While you can't take over the world quite yet with it, you can run just about any application on it, and even your entire virtual machine infrastructure. Need to manage secrets? There's a helm chart for that. Want to launch WordPress? Build resilient hyper-converged storage? Manage proxying for your entire network? K8s has you covered.
-- **Kubernetes LOVES The Cloud** - By this, I mean it's 'cloud native' as the cool kids call it. This means that running k8s on the cloud, or applications in k8s is very accessible. Instead of being bound to physical hardware, or being forced to use Amazon AWS or Google Cloud. No more being repressed!
+- **Kubernetes LOVES The Cloud** - By this, I mean it's 'cloud native' as the cool kids call it. This means that running k8s on the cloud, or applications in k8s, is very accessible, as it is no longer bound to physical hardware or forced to use Amazon AWS or Google Cloud. No more being repressed!
 
-**Your woes of being locked to certain hardware, or a special cloud are over!**
+**Your woes of being locked to certain hardware or a special cloud are over!**
 ![](https://i.giphy.com/l1yA7Vl6juVsk.webp)
 
 ## Trivia

--- a/home-lab/virtualization/kubernetes/k3s/deploy-ha-k3s-with-k3sup.md
+++ b/home-lab/virtualization/kubernetes/k3s/deploy-ha-k3s-with-k3sup.md
@@ -1,10 +1,10 @@
 # Deploy Highly-Available Kubernetes with `k3s` + `k3sup`
 
-`k3s` is a CNCF Cloud Native Landscape project that facilitates the quick-and-easy deployment of Kubernetes ("k8s"), which has allowed "k8s" to run on smaller devices, and more resource-constrained environments.
+`K3s` is a CNCF Cloud Native Landscape project that facilitates the quick-and-easy deployment of Kubernetes ("k8s"), which has allowed "k8s" to run on smaller devices, and more resource-constrained environments.
 
 
 
-**TL;DR?**: `k3s` is a great little all-in-one package of software(s) that allow you to be able to run Kubernetes without needing a large number of processor cores, or a large amount of RAM. You can run this on Raspberry Pis, Mini PCs, and more.
+**TL;DR?**: `k3s` is a great little all-in-one package of software that allows you to run Kubernetes without needing a large number of processor cores, or a large amount of RAM. You can run this on Raspberry Pis, Mini PCs, and more.
 
 ## Deploy your Virtual Machines
 
@@ -41,7 +41,7 @@ done
 4. Install k3s using this guide
    https://ma.ttias.be/deploying-highly-available-k3s-k3sup/#create-a-multi-master-ha-setup
 5. Install prerequisites for longhorn using this script:
-   ```bash
+```bash
 #!/bin/bash
 # Update and install dependencies
 echo "Updating system and installing prerequisites..."
@@ -74,7 +74,8 @@ systemctl is-active iscsid
 echo "Prerequisites installed successfully. Please ensure Kubernetes cluster is initialized before deploying Longhorn."
 ```
 6. Install Longhorn:
-   `helm install longhorn longhorn/longhorn --namespace longhorn-system --create-namespace --version 1.7.2`
+```bash
+   helm install longhorn longhorn/longhorn --namespace longhorn-system --create-namespace --version 1.7.2
 ```
 
 ## Inspiration Articles

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "name": "docs.reiffenberger.net",
+  "version": "1.0.0",
+  "main": "index.js",
   "dependencies": {
     "vitepress": "^1.6.3"
   },
@@ -6,5 +9,16 @@
     "docs:dev": "vitepress dev",
     "docs:build": "vitepress build",
     "docs:preview": "vitepress preview"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ReclaimerGold/docs.reiffenberger.net.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/ReclaimerGold/docs.reiffenberger.net/issues"
+  },
+  "homepage": "https://docs.reiffenberger.net/",
+  "description": ""
 }


### PR DESCRIPTION
The package.json should contain the really good information about a project. As example where to file bugs, what the homepage is, what version you are on, all of that fun stuff. While you are not planning on publishing this as a package this is one of the first spots that people use to gain an understanding about a project and what it is all about.   

Secondarily, I removed `npm cache clean --force` as there really is no need for that. Feel free to rebuttle but I am guessing it was a debugging step and thusly can be removed. 